### PR TITLE
Pr linode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ https://www.terraform.io/guides/writing-custom-terraform-providers.html
 1. Set up your GOPATH. A good default is $HOME/go. You can quickly set it by running `export GOPATH=$HOME/go`
 2. cd to your new GOPATH.
 3. Run `go get github.com/RainbowHackerHorse/terraform-provider-linode`
-4. `cd $GOPATH/src/github.com/RainbowHackerHorse/terraform-provider-linode`
-5. `go build -o terraform-provider-linode`
-6. Copy the resulting package from the ./pkg dir to wherever you want on your filesystem.
+4. `cd $GOPATH/src/github.com/RainbowHackerHorse/terraform-provider-linode/bin/terraform-provider-linode`
+5. `go build -o terraform-provider-linode` (To cross-compile for freebsd, run `GOOS=freebsd GOARCH=amd64 build -o terraform-provider-linode`)
+6. Copy the resulting package to wherever you want on your filesystem.
 7. Follow the above instructions for using it.

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ likely be tedious.
 ## Installation
 
 1. Download the plugin from the [releases tab][3]
+Both Linux and FreeBSD binaries are available.
 2. Put it somewhere were it can permanently live, it doesn't need to be in your path.
 3. Create or modify your `~/.terraformrc` file. You'll need at least this:
 

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ providers {
 
 If you didn't add terraform-provider-linode to your path, you'll need to put the full path to the location of the plugin.
 
-[3]:https://github.com/btobolaski/terraform-provider-linode/releases
+[3]:https://github.com/RainbowHackerHorse/terraform-provider-linode/releases
 
 ## Usage
 
@@ -92,10 +92,24 @@ value                             | Type     | Forces New | Value Type | Descrip
 ## Contributing
 
 1. Fork the repo
-2. Use [godep][3] to get the correct versions of the dependencies
+2. Use [godep][3] to get the correct versions of the dependencies, via `godep get`
 3. Make your changes
 4. Apply `go fmt` to all of the files
 5. Verify that the tests still pass
 6. Submit a pull request
 
 [3]:https://github.com/tools/godep
+
+## Building
+If you're unfamiliar with building go or terraform plugins, please visit the following links first:
+https://golang.org/pkg/go/build/
+https://golang.org/doc/install
+https://www.terraform.io/guides/writing-custom-terraform-providers.html
+
+1. Set up your GOPATH. A good default is $HOME/go. You can quickly set it by running `export GOPATH=$HOME/go`
+2. cd to your new GOPATH.
+3. Run `go get github.com/RainbowHackerHorse/terraform-provider-linode`
+4. `cd $GOPATH/src/github.com/RainbowHackerHorse/terraform-provider-linode`
+5. `go build -o terraform-provider-linode`
+6. Copy the resulting package from the ./pkg dir to wherever you want on your filesystem.
+7. Follow the above instructions for using it.

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ providers {
 
 If you didn't add terraform-provider-linode to your path, you'll need to put the full path to the location of the plugin.
 
-[3]:https://github.com/RainbowHackerHorse/terraform-provider-linode/releases
+[3]:https://github.com/LinodeContent/terraform-provider-linode/releases
 
 ## Usage
 
@@ -109,8 +109,8 @@ https://www.terraform.io/guides/writing-custom-terraform-providers.html
 
 1. Set up your GOPATH. A good default is $HOME/go. You can quickly set it by running `export GOPATH=$HOME/go`
 2. cd to your new GOPATH.
-3. Run `go get github.com/RainbowHackerHorse/terraform-provider-linode`
-4. `cd $GOPATH/src/github.com/RainbowHackerHorse/terraform-provider-linode/bin/terraform-provider-linode`
+3. Run `go get github.com/LinodeContent/terraform-provider-linode`
+4. `cd $GOPATH/src/github.com/LinodeContent/terraform-provider-linode/bin/terraform-provider-linode`
 5. `go build -o terraform-provider-linode` (To cross-compile for freebsd, run `GOOS=freebsd GOARCH=amd64 build -o terraform-provider-linode`)
 6. Copy the resulting package to wherever you want on your filesystem.
 7. Follow the above instructions for using it.


### PR DESCRIPTION
This PR updates the README.md file with accurate build information which has never been documented with this project in any capacity. Admittedly, that made barrier to entry hard even for someone with a few languages under their belt, if they've never used golang before and don't know its conventions.

Additionally, I've built and hosted fresh Linux and FreeBSD binaries for the plugin, as this whole exercise was so I could use the Linode provider on FreeBSD and not have to use AWS or *shudder* DO.

Linux and FreeBSD binaries are available at:
https://github.com/RainbowHackerHorse/terraform-provider-linode/releases/download/v0.1.1/terraform-provider-linode.tar.gz
Feel free to rehost this tarball (or simply edit the readme to link to my link).